### PR TITLE
Remove Pandas and NumPy

### DIFF
--- a/energypylinear/battery/battery.py
+++ b/energypylinear/battery/battery.py
@@ -1,8 +1,6 @@
 import logging
 import json
 
-import numpy as np
-import pandas as pd
 from pulp import LpProblem, LpMinimize, lpSum, LpVariable, LpStatus
 
 from energypylinear import make_logger, read_logs

--- a/energypylinear/tests/test_battery_economics.py
+++ b/energypylinear/tests/test_battery_economics.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import energypylinear
@@ -26,12 +25,14 @@ def test_cost_calculation(power, capacity, initial_charge, timestep):
         prices=prices, initial_charge=initial_charge
     )
 
-    dispatch = info.loc[:, 'Net [MW]'].values
+    dispatch = [res['Net [MW]'] for res in info if res['Net [MW]'] is not None]
     timestep = model.timestep
     step = model.step
-    check_actual_costs = sum(dispatch[:-1] * prices[:-1]) / step 
+    check_actual_costs = sum(
+        [d * p for d, p in zip(dispatch[:-1], prices[:-1])]
+    ) / step
 
-    actual_costs = info.loc[:, 'Actual [$/{}]'.format(timestep)].values
+    actual = 'Actual [$/{}]'.format(timestep)
+    actual_costs = [res[actual] for res in info if res[actual] is not None]
 
-    np.testing.assert_almost_equal(check_actual_costs, sum(actual_costs[:-1]))
-
+    assert round(check_actual_costs, 6) == round(sum(actual_costs[:-1]), 6)

--- a/energypylinear/tests/test_battery_efficiency.py
+++ b/energypylinear/tests/test_battery_efficiency.py
@@ -1,4 +1,4 @@
-import numpy as np
+import unittest
 import pytest
 
 import energypylinear
@@ -15,9 +15,9 @@ net = gross / 1.5
 @pytest.mark.parametrize(
     'prices, initial_charge, efficiency, expected_dispatch',
     [
-        ([10, 10, 10], 0, 0.5, [0, 0, np.nan]),
-        ([20, 10, 10], 1, 0.5, [1/1.5-1, 0, np.nan]),
-        ([10, 50, 10, 50, 10], 0, 0.5, [4, 4/1.5-4, 4, 4/1.5-4, np.nan])
+        ([10, 10, 10], 0, 0.5, [0.0, 0.0, None]),
+        ([20, 10, 10], 1, 0.5, [-0.33333334000000003, 0.0, None]),
+        ([10, 50, 10, 50, 10], 0, 0.5, [4.0, -1.3333334, 4.0, -1.3333334, None])
     ]
 )
 def test_battery_efficiency(prices, initial_charge, efficiency, expected_dispatch):
@@ -32,7 +32,6 @@ def test_battery_efficiency(prices, initial_charge, efficiency, expected_dispatc
         prices=prices, initial_charge=initial_charge
     )
 
-    dispatch = info.loc[:, 'Net [MW]'].values
+    dispatch = [res['Net [MW]'] for res in info]
 
-    np.testing.assert_array_almost_equal(dispatch, expected_dispatch)
-
+    unittest.TestCase().assertCountEqual(dispatch, expected_dispatch)

--- a/energypylinear/tests/test_battery_efficiency.py
+++ b/energypylinear/tests/test_battery_efficiency.py
@@ -12,6 +12,7 @@ gross = net * (1 - effy) + net
 net = gross / 1.5
 """
 
+
 @pytest.mark.parametrize(
     'prices, initial_charge, efficiency, expected_dispatch',
     [
@@ -20,7 +21,7 @@ net = gross / 1.5
         ([10, 50, 10, 50, 10], 0, 0.5, [4.0, -1.3333334, 4.0, -1.3333334, None])
     ]
 )
-def test_battery_efficiency(prices, initial_charge, efficiency, expected_dispatch):
+def test_batt_efficiency(prices, initial_charge, efficiency, expected_dispatch):
     power = 4
     capacity = 4
 

--- a/energypylinear/tests/test_battery_optimization.py
+++ b/energypylinear/tests/test_battery_optimization.py
@@ -1,14 +1,14 @@
-import numpy as np
 import pytest
+import unittest
 
 import energypylinear
 
 @pytest.mark.parametrize(
     'prices, initial_charge, expected_dispatch',
     [
-        ([10, 10, 10], 0, [0, 0, np.nan]),
-        ([20, 10, 10], 1, [-1, 0, np.nan]),
-        ([10, 50, 10, 50, 10], 0, [4, -4, 4, -4, np.nan])
+        ([10, 10, 10], 0, [0, 0, None]),
+        ([20, 10, 10], 1, [-1, 0, None]),
+        ([10, 50, 10, 50, 10], 0, [4, -4, 4, -4, None])
     ]
 )
 def test_battery_optimization(prices, initial_charge, expected_dispatch):
@@ -23,7 +23,5 @@ def test_battery_optimization(prices, initial_charge, expected_dispatch):
         prices=prices, initial_charge=initial_charge
     )
 
-    dispatch = info.loc[:, 'Net [MW]'].values
-
-    np.testing.assert_equal(dispatch, expected_dispatch)
-
+    dispatch = [res['Net [MW]'] for res in info]
+    unittest.TestCase().assertCountEqual(dispatch, expected_dispatch)

--- a/energypylinear/tests/test_battery_optimization.py
+++ b/energypylinear/tests/test_battery_optimization.py
@@ -3,6 +3,7 @@ import unittest
 
 import energypylinear
 
+
 @pytest.mark.parametrize(
     'prices, initial_charge, expected_dispatch',
     [

--- a/energypylinear/tests/test_battery_view.py
+++ b/energypylinear/tests/test_battery_view.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 import numpy as np
 
 import energypylinear
@@ -21,10 +22,11 @@ def test_view_output():
                        'Forecast [$/MWh]', 'Actual [$/5min]',
                        'Forecast [$/5min]']
 
+    results = pd.DataFrame(info, columns=info[0].keys())
     for header in expected_header:
-        assert(header in info.columns)
+        assert(header in results.columns)
 
-    result_rows = info.values.tolist()
+    result_rows = results.values.tolist()
     assert result_rows[0] == [2.0, 0.0, 2.0, 2.0, 0.0, 0.0, 10.0, 10.0, 1.6666666666666667, 1.6666666666666667]
     assert result_rows[1] == [2.0, 0.0, 2.0, 2.0, 0.0, 0.16666667, 20.0, 20.0, 3.3333333333333335, 3.3333333333333335]
     assert result_rows[2] == [0.0, 1.6363636, -1.6363636, -1.47272724, 0.16363636, 0.33333333, 30.0, 30.0, -3.6818180999999996, -3.6818180999999996]

--- a/energypylinear/tests/test_battery_view.py
+++ b/energypylinear/tests/test_battery_view.py
@@ -2,9 +2,6 @@ import pytest
 import io
 import csv
 
-import pandas as pd
-import numpy as np
-
 import energypylinear
 
 
@@ -34,18 +31,15 @@ def test_view_output():
     for row in info:
         writer.writerow(row)
 
-    import pdb;pdb.set_trace()
-    results = pd.DataFrame(info, columns=info[0].keys())
+    csv_rows = csvfile.getvalue().split('\r\n')
     for header in expected_header:
-        assert(header in results.columns)
+        assert(header in csv_rows[0])
 
-    result_rows = results.values.tolist()
-    assert result_rows[0] == [2.0, 0.0, 2.0, 2.0, 0.0, 0.0, 10.0, 10.0, 1.6666666666666667, 1.6666666666666667]
-    assert result_rows[1] == [2.0, 0.0, 2.0, 2.0, 0.0, 0.16666667, 20.0, 20.0, 3.3333333333333335, 3.3333333333333335]
-    assert result_rows[2] == [0.0, 1.6363636, -1.6363636, -1.47272724, 0.16363636, 0.33333333, 30.0, 30.0, -3.6818180999999996, -3.6818180999999996]
-    assert result_rows[3] == [0.0, 2.0, -2.0, -1.8, 0.2, 0.18333333, 40.0, 40.0, -6.0, -6.0]
-    assert result_rows[4] == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 10.0, 0.0, 0.0]
-    assert np.isnan(result_rows[5]).any()
-    assert result_rows[5][5] == 0.0
-    assert result_rows[5][6] == 50.0
-    assert result_rows[5][7] == 50.0
+    assert csv_rows[1] == ",".join(map(str, [2.0, 0.0, 2.0, 2.0, 0.0, 0.0, 10, 10, 1.6666666666666667, 1.6666666666666667]))
+    assert csv_rows[2] == ",".join(map(str, [2.0, 0.0, 2.0, 2.0, 0.0, 0.16666667, 20, 20, 3.3333333333333335, 3.3333333333333335]))
+    assert csv_rows[3] == ",".join(map(str, [0.0, 1.6363636, -1.6363636, -1.47272724, 0.16363636, 0.33333333, 30, 30, -3.6818180999999996, -3.6818180999999996]))
+    assert csv_rows[4] == ",".join(map(str, [0.0, 2.0, -2.0, -1.8, 0.2, 0.18333333, 40, 40, -6.0, -6.0]))
+    assert csv_rows[5] == ",".join(map(str, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10, 10, 0.0, 0.0]))
+    assert csv_rows[6].split(",")[5] == "0.0"
+    assert csv_rows[6].split(",")[6] == "50"
+    assert csv_rows[6].split(",")[7] == "50"

--- a/energypylinear/tests/test_battery_view.py
+++ b/energypylinear/tests/test_battery_view.py
@@ -1,0 +1,36 @@
+import pytest
+import numpy as np
+
+import energypylinear
+
+
+def test_view_output():
+    """Test that we output the expected view."""
+    prices = [10, 20, 30, 40, 10, 50]
+
+    model = energypylinear.Battery(
+        power=2, capacity=4
+    )
+
+    info = model.optimize(
+        prices=prices, initial_charge=0
+    )
+
+    expected_header = ['Import [MW]', 'Export [MW]', 'Gross [MW]', 'Net [MW]',
+                       'Losses [MW]', 'Charge [MWh]', 'Prices [$/MWh]',
+                       'Forecast [$/MWh]', 'Actual [$/5min]',
+                       'Forecast [$/5min]']
+
+    for header in expected_header:
+        assert(header in info.columns)
+
+    result_rows = info.values.tolist()
+    assert result_rows[0] == [2.0, 0.0, 2.0, 2.0, 0.0, 0.0, 10.0, 10.0, 1.6666666666666667, 1.6666666666666667]
+    assert result_rows[1] == [2.0, 0.0, 2.0, 2.0, 0.0, 0.16666667, 20.0, 20.0, 3.3333333333333335, 3.3333333333333335]
+    assert result_rows[2] == [0.0, 1.6363636, -1.6363636, -1.47272724, 0.16363636, 0.33333333, 30.0, 30.0, -3.6818180999999996, -3.6818180999999996]
+    assert result_rows[3] == [0.0, 2.0, -2.0, -1.8, 0.2, 0.18333333, 40.0, 40.0, -6.0, -6.0]
+    assert result_rows[4] == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 10.0, 0.0, 0.0]
+    assert np.isnan(result_rows[5]).any()
+    assert result_rows[5][5] == 0.0
+    assert result_rows[5][6] == 50.0
+    assert result_rows[5][7] == 50.0

--- a/energypylinear/tests/test_battery_view.py
+++ b/energypylinear/tests/test_battery_view.py
@@ -1,4 +1,7 @@
 import pytest
+import io
+import csv
+
 import pandas as pd
 import numpy as np
 
@@ -22,6 +25,16 @@ def test_view_output():
                        'Forecast [$/MWh]', 'Actual [$/5min]',
                        'Forecast [$/5min]']
 
+    csvfile = io.StringIO()
+    fieldnames = info[0].keys()
+    writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+    writer.writeheader()
+
+    for row in info:
+        writer.writerow(row)
+
+    import pdb;pdb.set_trace()
     results = pd.DataFrame(info, columns=info[0].keys())
     for header in expected_header:
         assert(header in results.columns)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
 
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
-    install_requires=[]
+    install_requires=['PuLP']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='energypylinear',
 
-    version='0.0.1',
+    version='0.0.2',
     description='linear programming for energy systems',
     author='Adam Green',
     author_email='adam.green@adgefficiency.com',


### PR DESCRIPTION
## Removing Pandas and Numpy as dependancies.

These are both pretty large and aren't adding anything substantial to the library. Users of the library and dependant code bases will be happier for it.

I've added a test to the output of the view. I've written the test such as it will check for equality when changing the output from a DataFrame to a Dict. There is def room for better refactoring of that test (and other parts)

#### Type Changes
The result is no longer a DataFrame, but a Dict. When using the library, we can do what we want with this Dict, including `pd.DataFrame(dict)`, or write to a csv, or just pull certain parts out of it.

Instead of applying formula to Series, I'm looping through each result and cleaning the data to insert into the result set. It gets rid of a lot of the use of `iloc` which will be unfamiliar to non-pandas users and instead of `info.loc[:, 'Import [MW]'] - info.loc[:, 'Export [MW]']` we can have `import - export`. Hopefully it makes for more readable code.

Lots of NumPy in the test suite was being used to do things like compare lists, or fuzzy compare. Here, I've used list comprehensions and routing to achieve the same thing.

NumPy was also being used for it's `NaN`. I've used `None` instead.

##### Setup Changes
I've added pulp as an `install_requires`. listing requirements in setup.py instead of requirements will make it easier to use as a pip installable library.

And, I've added an alias for pytest so the test suite can be run with `python setup.py test`
