### PR TITLE
including packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
     name='energypylinear',
 
-    version='0.0.2',
+    version='0.0.3',
     description='linear programming for energy systems',
     author='Adam Green',
     author_email='adam.green@adgefficiency.com',
     url='http://www.adgefficiency.com/',
 
-    packages=['energypylinear/battery'],
+    packages=find_packages(exclude=['tests', 'tests.*']),
 
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],


### PR DESCRIPTION
Using find_packages to include folders with `__init__.py` as packages. Fixes some importing bugs when using the library.