### PR TITLE
removed final NaN row by introducing an initial and final charge

### DIFF
--- a/energypylinear/battery/battery.py
+++ b/energypylinear/battery/battery.py
@@ -207,7 +207,6 @@ if __name__ == '__main__':
 
     info = model.optimize(prices, initial_charge=0, timestep='1hr')
 
-    import pandas as pd
+    from pprint import pprint as pp
 
-    info = pd.DataFrame(info)
-    sub = info.loc[:, ['Initial charge [MWh]', 'Final charge [MWh]', 'Gross [MW]', 'Net [MW]']]
+    pp(info)

--- a/energypylinear/tests/test_battery.py
+++ b/energypylinear/tests/test_battery.py
@@ -28,12 +28,16 @@ def test_power_capacity_initial_charge(power, capacity, initial_charge):
     assert(min(dispatch) >= -power)
 
     #  check we don't exceed battery capacity
-    charges = map_values(info, 'Charge [MWh]')
-    assert(max(charges) <= capacity)
-    assert(min(charges) >= 0)
+    i_charges = map_values(info, 'Initial charge [MWh]')
+    assert(max(i_charges) <= capacity)
+    assert(min(i_charges) >= 0)
+
+    f_charges = map_values(info, 'Final charge [MWh]')
+    assert(max(f_charges) <= capacity)
+    assert(min(f_charges) >= 0)
 
     #  check we set initial charge correctly
-    assert(charges[0] == initial_charge)
+    assert(i_charges[0] == initial_charge)
 
     # check gross is greater or eq to net
     gross = [abs(x) for x in map_values(info, 'Gross [MW]')]

--- a/energypylinear/tests/test_battery_efficiency.py
+++ b/energypylinear/tests/test_battery_efficiency.py
@@ -16,9 +16,9 @@ net = gross / 1.5
 @pytest.mark.parametrize(
     'prices, initial_charge, efficiency, expected_dispatch',
     [
-        ([10, 10, 10], 0, 0.5, [0.0, 0.0, 0.0, None]),
-        ([20, 10, 10], 1, 0.5, [-0.33333334000000003, 0.0, 0.0, None]),
-        ([10, 50, 10, 50, 10], 0, 0.5, [4.0, -1.3333334, 4.0, -1.3333334, 0.0, None])
+        ([10, 10, 10], 0, 0.5, [0.0, 0.0, 0.0]),
+        ([20, 10, 10], 1, 0.5, [-0.33333334000000003, 0.0, 0.0]),
+        ([10, 50, 10, 50, 10], 0, 0.5, [4.0, -1.3333334, 4.0, -1.3333334, 0.0])
     ]
 )
 def test_batt_efficiency(prices, initial_charge, efficiency, expected_dispatch):

--- a/energypylinear/tests/test_battery_optimization.py
+++ b/energypylinear/tests/test_battery_optimization.py
@@ -7,9 +7,9 @@ import energypylinear
 @pytest.mark.parametrize(
     'prices, initial_charge, expected_dispatch',
     [
-        ([10, 10, 10], 0, [0, 0, 0, None]),
-        ([20, 10, 10], 1, [-1, 0, 0, None]),
-        ([10, 50, 10, 50, 10], 0, [4, -4, 4, -4, 0, None])
+        ([10, 10, 10], 0, [0, 0, 0]),
+        ([20, 10, 10], 1, [-1, 0, 0]),
+        ([10, 50, 10, 50, 10], 0, [4, -4, 4, -4, 0])
     ]
 )
 def test_battery_optimization(prices, initial_charge, expected_dispatch):
@@ -38,4 +38,4 @@ def test_battery_optimization_against_forecast():
     )
 
     result = [res['Net [MW]'] for res in info]
-    unittest.TestCase().assertCountEqual(result, [0, 0, 0, None])
+    unittest.TestCase().assertCountEqual(result, [0, 0, 0])

--- a/energypylinear/tests/test_battery_view.py
+++ b/energypylinear/tests/test_battery_view.py
@@ -17,7 +17,8 @@ def test_view_output():
         prices=prices, initial_charge=0, timestep='1hr'
     )
     expected_header = ['Import [MW]', 'Export [MW]', 'Gross [MW]', 'Net [MW]',
-                       'Losses [MW]', 'Charge [MWh]', 'Prices [$/MWh]',
+                       'Losses [MW]', 'Initial charge [MWh]', 'Final charge [MWh]',
+                       'Prices [$/MWh]',
                        'Forecast [$/MWh]', 'Actual [$/1hr]',
                        'Forecast [$/1hr]']
 


### PR DESCRIPTION
Running the sample problem in the if/name/main block of `battery.py`:

model = Battery(power=2, capacity=4)
info = model.optimize(prices, initial_charge=0, timestep='1hr')

Gives:

[OrderedDict([('Import [MW]', 0.0),
              ('Export [MW]', 0.0),
              ('Gross [MW]', 0.0),
              ('Net [MW]', 0.0),
              ('Losses [MW]', 0.0),
              ('Initial charge [MWh]', 0.0),
              ('Final charge [MWh]', 0.0),
              ('Prices [$/MWh]', 50),
              ('Forecast [$/MWh]', 50),
              ('Actual [$/1hr]', 0.0),
              ('Forecast [$/1hr]', 0.0)]),
 OrderedDict([('Import [MW]', 2.0),
              ('Export [MW]', 0.0),
              ('Gross [MW]', 2.0),
              ('Net [MW]', 2.0),
              ('Losses [MW]', 0.0),
              ('Initial charge [MWh]', 0.0),
              ('Final charge [MWh]', 2.0),
              ('Prices [$/MWh]', 10),
              ('Forecast [$/MWh]', 10),
              ('Actual [$/1hr]', 20.0),
              ('Forecast [$/1hr]', 20.0)]),
 OrderedDict([('Import [MW]', 2.0),
              ('Export [MW]', 0.0),
              ('Gross [MW]', 2.0),
              ('Net [MW]', 2.0),
              ('Losses [MW]', 0.0),
              ('Initial charge [MWh]', 2.0),
              ('Final charge [MWh]', 4.0),
              ('Prices [$/MWh]', 10),
              ('Forecast [$/MWh]', 10),
              ('Actual [$/1hr]', 20.0),
              ('Forecast [$/1hr]', 20.0)]),
 OrderedDict([('Import [MW]', 0.0),
              ('Export [MW]', 2.0),
              ('Gross [MW]', -2.0),
              ('Net [MW]', -1.8),
              ('Losses [MW]', 0.2),
              ('Initial charge [MWh]', 4.0),
              ('Final charge [MWh]', 1.8),
              ('Prices [$/MWh]', 50),
              ('Forecast [$/MWh]', 50),
              ('Actual [$/1hr]', -90.0),
              ('Forecast [$/1hr]', -90.0)]),
 OrderedDict([('Import [MW]', 0.0),
              ('Export [MW]', 1.6363636),
              ('Gross [MW]', -1.6363636),
              ('Net [MW]', -1.47272724),
              ('Losses [MW]', 0.16363636),
              ('Initial charge [MWh]', 1.8),
              ('Final charge [MWh]', 0.0),
              ('Prices [$/MWh]', 50),
              ('Forecast [$/MWh]', 50),
              ('Actual [$/1hr]', -73.636362),
              ('Forecast [$/1hr]', -73.636362)]),
 OrderedDict([('Import [MW]', 0.0),
              ('Export [MW]', 0.0),
              ('Gross [MW]', 0.0),
              ('Net [MW]', 0.0),
              ('Losses [MW]', 0.0),
              ('Initial charge [MWh]', 0.0),
              ('Final charge [MWh]', 0.0),
              ('Prices [$/MWh]', 10),
              ('Forecast [$/MWh]', 10),
              ('Actual [$/1hr]', 0.0),
              ('Forecast [$/1hr]', 0.0)])]