### PR TITLE
Separate Charge and Discharge Battery Power

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,12 @@ lint: setup-check
 	ruff format --check **/*.py
 	poetry check
 
+CHECK_DOCSTRINGS=./energypylinear/assets/battery.py
+
+# currently only run manually
+lint-docstrings:
+	flake8 --extend-ignore E501 --exclude=__init__.py,poc $(CHECK_DOCSTRINGS)
+	pydocsytle $(CHECK_DOCSTRINGS)
 
 #  ----- FORMATTING -----
 

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ CHECK_DOCSTRINGS=./energypylinear/assets/battery.py
 lint-docstrings:
 	flake8 --extend-ignore E501 --exclude=__init__.py,poc $(CHECK_DOCSTRINGS)
 	pydocsytle $(CHECK_DOCSTRINGS)
+	pylint $(CHECK_DOCSTRINGS) --rcfile .pylintrc
 
 #  ----- FORMATTING -----
 

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,9 @@ CHECK_DOCSTRINGS=./energypylinear/assets/battery.py
 
 # currently only run manually
 lint-docstrings:
-	flake8 --extend-ignore E501 --exclude=__init__.py,poc $(CHECK_DOCSTRINGS)
-	pydocsytle $(CHECK_DOCSTRINGS)
-	pylint $(CHECK_DOCSTRINGS) --rcfile .pylintrc
+	flake8 --extend-ignore E501 --exclude=__init__.py,poc --exit-zero $(CHECK_DOCSTRINGS)
+	pydocstyle $(CHECK_DOCSTRINGS)
+	pylint $(CHECK_DOCSTRINGS)
 
 #  ----- FORMATTING -----
 

--- a/docs/docs/assets/battery.md
+++ b/docs/docs/assets/battery.md
@@ -1,14 +1,14 @@
 # Battery
 
-The `epl.Battery` model is suitable for modelling an electric battery, such as a Lithium-Ion battery.
+The `epl.Battery` model is suitable for modelling an electric battery, such as a lithium-ion battery.
 
-The size of the battery charge rate is defined by `power_mw`, which will define the maximum rate of charge and discharge. `discharge_power_mw` can be used to define a different rate of maximum discharge.
+The battery charge rate is defined by `power_mw`, which defines both the maximum rate of charge and discharge. `discharge_power_mw` can be used to define a different rate of maximum discharge.
 
-The size of the battery storage capacity is defined by `capacity_mwh`.  This is the capacity after taking into account any battery depth of discharge limits.
+The battery storage capacity is defined by `capacity_mwh`.  This should be the capacity after taking into account any battery depth of discharge limits.
 
 An efficiency penalty is applied to the battery charge energy, based on the `efficiency_pct` parameter.  No electricity is lost when discharging or during storage.
 
-`initial_charge_mwh` and `final_charge_mwh` control the battery state of charge at the start and end of the simulation.
+`initial_charge_mwh` and `final_charge_mwh` control the battery state of charge at the start and end of the simulation.  These can cause infeasible simulations if the battery is not able to charge or discharge enough to meet these constraints.
 
 [You can check the correctness of the battery model here](https://energypylinear.adgefficiency.com/latest/validation/battery/).
 

--- a/docs/docs/assets/battery.md
+++ b/docs/docs/assets/battery.md
@@ -1,33 +1,32 @@
 # Battery
 
-Optimize an electric battery operating in wholesale price arbitrage using `epl.Battery`:
+The `epl.Battery` model is suitable for modelling an electric battery, such as a Lithium-Ion battery.
+
+The size of the battery charge rate is defined by `power_mw`, which will define the maximum rate of charge and discharge. `discharge_power_mw` can be used to define a different rate of maximum discharge.
+
+The size of the battery storage capacity is defined by `capacity_mwh`.  This is the capacity after taking into account any battery depth of discharge limits.
+
+An efficiency penalty is applied to the battery charge energy, based on the `efficiency_pct` parameter.  No electricity is lost when discharging or during storage.
+
+`initial_charge_mwh` and `final_charge_mwh` control the battery state of charge at the start and end of the simulation.
+
+[You can check the correctness of the battery model here](https://energypylinear.adgefficiency.com/latest/validation/battery/).
 
 ```python
 import energypylinear as epl
 
-#  optimize a 2.0 MW, 4.0 MWh battery for money
 asset = epl.Battery(
     power_mw=2,
+    discharge_power_mw=2,
     capacity_mwh=4,
     efficiency_pct=0.9,
     electricity_prices=[100.0, 50, 200, -100, 0, 200, 100, -100],
     freq_mins=60,
     initial_charge_mwh=1,
     final_charge_mwh=3,
+    name="battery"
 )
-simulation = asset.optimize(objective="price")
-
-#  optimize a 1.0 MW, 3.0 MWh battery for carbon
-asset = epl.Battery(
-    power_mw=1,
-    capacity_mwh=3,
-    efficiency_pct=0.9,
-    electricity_carbon_intensities=[0.1, 0.2, 0.1, 0.15, 0.01, 0.7, 0.5, 0.01],
-    freq_mins=60,
-    initial_charge_mwh=0,
-    final_charge_mwh=0,
-)
-simulation = asset.optimize(objective="carbon")
+simulation = asset.optimize()
 
 assert all(
     simulation.results.columns
@@ -70,9 +69,3 @@ assert all(
     ]
 )
 ```
-
-The battery will charge with electricity at low prices & carbon intensities, and discharge at high prices & carbon intensities.
-
-An efficiency penalty is applied to the battery charge energy (energy is lost during charging).
-
-[You can check the correctness of the battery model here](https://energypylinear.adgefficiency.com/latest/validation/battery/).

--- a/energypylinear/assets/battery.py
+++ b/energypylinear/assets/battery.py
@@ -16,11 +16,11 @@ from energypylinear.optimizer import Optimizer
 def setup_initial_final_charge(
     initial_charge_mwh: float, final_charge_mwh: float | None, capacity_mwh: float
 ) -> tuple[float, float]:
-    """Determine the initial and final battery state of charge, taking into account the battery capacity.
+    """Determine initial and final battery state of charge, taking into account battery capacity.
 
     Args:
         initial_charge_mwh: state of charge at the start of the simulation in megawatt hours.
-        final_charge_mwh: state of charge at the end of the simulation in megawatt hours. If None, defaults to the initial charge.
+        final_charge_mwh: state of charge at the end of the simulation in megawatt hours. Defaults to the initial charge.
         capacity_mwh: battery capacity in megawatt hours.
 
     Returns:
@@ -140,17 +140,16 @@ def constrain_connection_batteries_between_intervals(
     """
     #  if in first interval, do nothing, could also do something based on `i` here...
     if len(two_intervals) < 2:
-        return None
+        return
 
-    else:
-        old = two_intervals[-2]
-        new = two_intervals[-1]
-        for alt, neu in zip(old, new, strict=True):
-            assert isinstance(alt, BatteryOneInterval)
-            assert isinstance(neu, BatteryOneInterval)
-            optimizer.constrain(
-                alt.electric_final_charge_mwh == neu.electric_initial_charge_mwh
-            )
+    old = two_intervals[-2]
+    new = two_intervals[-1]
+    for alt, neu in zip(old, new, strict=True):
+        assert isinstance(alt, BatteryOneInterval)
+        assert isinstance(neu, BatteryOneInterval)
+        optimizer.constrain(
+            alt.electric_final_charge_mwh == neu.electric_initial_charge_mwh
+        )
 
 
 def constrain_initial_final_charge(
@@ -302,9 +301,7 @@ class Battery(epl.Asset):
         constrain_only_charge_or_discharge(optimizer, battery)
         constrain_battery_electricity_balance(optimizer, battery)
 
-        #  TODO this is one battery asset, all intervals
-        #  maybe refactor into the after intervals?
-        #  bit of a weird case really
+        #  one battery asset, all intervals
         all_batteries = ivars.filter_objective_variables_all_intervals(
             instance_type=BatteryOneInterval, asset_name=self.cfg.name
         )

--- a/energypylinear/assets/battery.py
+++ b/energypylinear/assets/battery.py
@@ -16,7 +16,16 @@ from energypylinear.optimizer import Optimizer
 def setup_initial_final_charge(
     initial_charge_mwh: float, final_charge_mwh: float | None, capacity_mwh: float
 ) -> tuple[float, float]:
-    """Processes the initial and final charge of battery storage."""
+    """Determine the initial and final battery state of charge, taking into account the battery capacity.
+
+    Args:
+        initial_charge_mwh: state of charge at the start of the simulation in megawatt hours.
+        final_charge_mwh: state of charge at the end of the simulation in megawatt hours. If None, defaults to the initial charge.
+        capacity_mwh: battery capacity in megawatt hours.
+
+    Returns:
+        A tuple of initial and final charge, both in megawatt hours.
+    """
     initial_charge_mwh = min(initial_charge_mwh, capacity_mwh)
     final_charge_mwh = (
         initial_charge_mwh
@@ -30,7 +39,8 @@ class BatteryConfig(pydantic.BaseModel):
     """Battery asset configuration."""
 
     name: str
-    power_mw: float
+    charge_power_mw: float
+    discharge_power_mw: float
     capacity_mwh: float
     efficiency_pct: float
     initial_charge_mwh: float = 0.0
@@ -40,8 +50,14 @@ class BatteryConfig(pydantic.BaseModel):
     @pydantic.field_validator("name")
     @classmethod
     def check_name(cls, name: str) -> str:
-        """Ensure we can identify this asset correctly."""
+        """Ensure we can identify this asset correctly.
 
+        Args:
+            name: asset name.
+
+        Returns:
+            The asset name.
+        """
         assert "battery" in name
         return name
 
@@ -62,64 +78,73 @@ class BatteryOneInterval(AssetOneInterval):
 
 def constrain_only_charge_or_discharge(
     optimizer: Optimizer,
-    battery: AssetOneInterval,
-    flags: Flags,
+    one_interval: AssetOneInterval,
 ) -> None:
     """Constrain battery to only charge or discharge.
 
-    Usually flagged off - slows things down a lot (~2x as slow).
-
-    Instead of forcing only charge or discharge, the objective function just takes the
-    difference to calculate net charge.
+    Args:
+        optimizer: an epl.Optimizer.
+        one_interval: linear program variables for a single interval.
     """
-    assert isinstance(battery, BatteryOneInterval)
+    assert isinstance(one_interval, BatteryOneInterval)
     optimizer.constrain_max(
-        battery.electric_charge_mwh,
-        battery.electric_charge_binary,
-        battery.cfg.capacity_mwh,
+        one_interval.electric_charge_mwh,
+        one_interval.electric_charge_binary,
+        one_interval.cfg.capacity_mwh,
     )
     optimizer.constrain_max(
-        battery.electric_discharge_mwh,
-        battery.electric_discharge_binary,
-        battery.cfg.capacity_mwh,
+        one_interval.electric_discharge_mwh,
+        one_interval.electric_discharge_binary,
+        one_interval.cfg.capacity_mwh,
     )
     optimizer.constrain(
-        battery.electric_charge_binary + battery.electric_discharge_binary <= 1
+        one_interval.electric_charge_binary + one_interval.electric_discharge_binary
+        <= 1
     )
 
 
 def constrain_battery_electricity_balance(
-    optimizer: Optimizer, battery: AssetOneInterval
+    optimizer: Optimizer, one_interval: AssetOneInterval
 ) -> None:
-    """Constrain energy balance in a single interval - also calculates losses."""
-    assert isinstance(battery, BatteryOneInterval)
+    """Constrain battery energy balance in a single interval.
+
+    Calculates losses as a percentage of the battery charge.
+
+    Args:
+        optimizer: an epl.Optimizer.
+        one_interval: linear program variables for a single interval.
+    """
+    assert isinstance(one_interval, BatteryOneInterval)
     optimizer.constrain(
-        battery.electric_initial_charge_mwh
-        + battery.electric_charge_mwh
-        - battery.electric_discharge_mwh
-        - battery.electric_loss_mwh
-        == battery.electric_final_charge_mwh
+        one_interval.electric_initial_charge_mwh
+        + one_interval.electric_charge_mwh
+        - one_interval.electric_discharge_mwh
+        - one_interval.electric_loss_mwh
+        == one_interval.electric_final_charge_mwh
     )
     optimizer.constrain(
-        battery.electric_loss_mwh
-        == battery.electric_charge_mwh * (1 - battery.efficiency_pct)
+        one_interval.electric_loss_mwh
+        == one_interval.electric_charge_mwh * (1 - one_interval.efficiency_pct)
     )
 
 
 def constrain_connection_batteries_between_intervals(
     optimizer: Optimizer,
-    batteries: list[list[AssetOneInterval]],
+    two_intervals: list[list[AssetOneInterval]],
 ) -> None:
-    """Constrain battery dispatch between two adjacent intervals."""
+    """Constrain battery between two adjacent intervals.
 
-    #  if in first interval, do nothing
-    #  could also do something based on `i` here...
-    if len(batteries) < 2:
+    Args:
+        optimizer: An epl.Optimizer.
+        two_intervals: Linear program variables for two intervals.
+    """
+    #  if in first interval, do nothing, could also do something based on `i` here...
+    if len(two_intervals) < 2:
         return None
 
     else:
-        old = batteries[-2]
-        new = batteries[-1]
+        old = two_intervals[-2]
+        new = two_intervals[-1]
         for alt, neu in zip(old, new, strict=True):
             assert isinstance(alt, BatteryOneInterval)
             assert isinstance(neu, BatteryOneInterval)
@@ -131,7 +156,13 @@ def constrain_connection_batteries_between_intervals(
 def constrain_initial_final_charge(
     optimizer: Optimizer, initial: AssetOneInterval, final: AssetOneInterval
 ) -> None:
-    """Constrain the battery state of charge at the start and end of the simulation."""
+    """Constrain the battery state of charge at the start and end of the simulation.
+
+    Args:
+        optimizer: an epl.Optimizer.
+        initial: linear program variables for the first interval.
+        final: linear program variables for the last interval.
+    """
     assert isinstance(initial, BatteryOneInterval)
     assert isinstance(final, BatteryOneInterval)
     optimizer.constrain(
@@ -141,22 +172,12 @@ def constrain_initial_final_charge(
 
 
 class Battery(epl.Asset):
-    """Electric battery asset, able to charge and discharge electricity.
-
-    Args:
-        power_mw: the maximum power output of the battery in mega-watts, used for both charge and discharge.
-        capacity_mwh: battery capacity in mega-watt hours.
-        efficiency_pct: round-trip efficiency of the battery, with a default value of 90% efficient.
-        name: the asset name.
-        electricity_prices: the price of electricity in each interval.
-        electricity_carbon_intensities: carbon intensity of electricity in each interval.
-        initial_charge_mwh: initial charge state of the battery in mega-watt hours.
-        final_charge_mwh: final charge state of the battery in mega-watt hours.
-    """
+    """Electric battery asset, able to charge and discharge electricity."""
 
     def __init__(
         self,
         power_mw: float = 2.0,
+        discharge_power_mw: float | None = None,
         capacity_mwh: float = 4.0,
         efficiency_pct: float = 0.9,
         name: str = "battery",
@@ -167,15 +188,33 @@ class Battery(epl.Asset):
         final_charge_mwh: float | None = None,
         freq_mins: int = defaults.freq_mins,
     ):
-        """Initializes the asset."""
+        """Initialize the asset.
 
+        Args:
+            power_mw: Maximum charge rate in megawatts. Will define both the charge and discharge rate if `discharge_power_mw` is None.
+            discharge_power_mw: Maximum discharge rate in megawatts.
+            capacity_mwh: Battery capacity in megawatt hours.
+            efficiency_pct: Round-trip efficiency of the battery.
+            name: The asset name.
+            electricity_prices: The price of import electricity in each interval. Will define both import and export prices if `export_electricity_prices` is None.
+            export_electricity_prices: The price of export electricity in each interval.
+            electricity_carbon_intensities: Carbon intensity of electricity in each interval.
+            initial_charge_mwh: Initial charge state of the battery in megawatt hours.
+            final_charge_mwh: Final charge state of the battery in megawatt hours.
+            freq_mins: length of the simulation intervals in minutes.
+        """
         initial_charge_mwh, final_charge_mwh = setup_initial_final_charge(
             initial_charge_mwh, final_charge_mwh, capacity_mwh
         )
 
+        if discharge_power_mw is None:
+            discharge_power_mw = power_mw
+        assert discharge_power_mw
+
         self.cfg = BatteryConfig(
             name=name,
-            power_mw=power_mw,
+            charge_power_mw=power_mw,
+            discharge_power_mw=discharge_power_mw,
             capacity_mwh=capacity_mwh,
             efficiency_pct=efficiency_pct,
             initial_charge_mwh=initial_charge_mwh,
@@ -194,22 +233,29 @@ class Battery(epl.Asset):
             )
 
     def __repr__(self) -> str:
-        """A string representation of self."""
-        return f"<energypylinear.Battery {self.cfg.power_mw=} {self.cfg.capacity_mwh=}>"
+        """Return a string representation of self."""
+        return f"<energypylinear.Battery {self.cfg.charge_power_mw=} {self.cfg.capacity_mwh=}>"
 
     def one_interval(
         self, optimizer: Optimizer, i: int, freq: Freq, flags: Flags = Flags()
     ) -> BatteryOneInterval:
-        """Generate linear program data for one interval."""
+        """Generate linear program data for one interval.
+
+        Args:
+            optimizer: An epl.Optimizer.
+            i: Integer index of the current interval.
+            freq: Interval frequency.
+            flags: Boolean flags to change simulation and results behaviour.
+        """
         return BatteryOneInterval(
             cfg=self.cfg,
             electric_charge_mwh=optimizer.continuous(
                 f"{self.cfg.name}-electric_charge_mwh-{i}",
-                up=freq.mw_to_mwh(self.cfg.power_mw),
+                up=freq.mw_to_mwh(self.cfg.charge_power_mw),
             ),
             electric_discharge_mwh=optimizer.continuous(
                 f"{self.cfg.name}-electric_discharge_mwh-{i}",
-                up=freq.mw_to_mwh(self.cfg.power_mw),
+                up=freq.mw_to_mwh(self.cfg.discharge_power_mw),
             ),
             electric_charge_binary=optimizer.binary(
                 f"{self.cfg.name}-electric_charge_binary-{i}"
@@ -241,11 +287,19 @@ class Battery(epl.Asset):
         freq: Freq,
         flags: Flags = Flags(),
     ) -> None:
-        """Constrain asset within an interval."""
+        """Constrain asset within an interval.
+
+        Args:
+            optimizer: An epl.Optimizer.
+            ivars: An epl.IntervalVars.
+            i: Integer index of the current interval.
+            freq: Interval frequency.
+            flags: Boolean flags to change simulation and results behaviour.
+        """
         battery = ivars.filter_objective_variables(
             instance_type=BatteryOneInterval, i=-1, asset_name=self.cfg.name
         )[0]
-        constrain_only_charge_or_discharge(optimizer, battery, flags)
+        constrain_only_charge_or_discharge(optimizer, battery)
         constrain_battery_electricity_balance(optimizer, battery)
 
         #  TODO this is one battery asset, all intervals
@@ -262,7 +316,12 @@ class Battery(epl.Asset):
         optimizer: Optimizer,
         ivars: "epl.IntervalVars",
     ) -> None:
-        """Constrain asset after all intervals."""
+        """Constrain asset after all intervals.
+
+        Args:
+            optimizer: An epl.Optimizer.
+            ivars: An epl.IntervalVars.
+        """
         initial = ivars.filter_objective_variables(
             instance_type=BatteryOneInterval, i=0, asset_name=self.cfg.name
         )[0]
@@ -283,13 +342,13 @@ class Battery(epl.Asset):
         """Optimize the asset.
 
         Args:
-            objective: the optimization objective - either "price" or "carbon".
-            flags: boolean flags to change simulation and results behaviour.
-            verbose: level of printing.
-            optimizer_config: configuration options for the optimizer.
+            objective: The optimization objective - either "price" or "carbon".
+            verbose: Level of printing.
+            flags: Boolean flags to change simulation and results behaviour.
+            optimizer_config: Configuration options for the optimizer.
 
         Returns:
-            epl.results.SimulationResult
+            The simulation results.
         """
         return self.site.optimize(
             objective=objective,
@@ -299,5 +358,10 @@ class Battery(epl.Asset):
         )
 
     def plot(self, results: "epl.SimulationResult", path: pathlib.Path | str) -> None:
-        """Plot simulation results."""
+        """Plot simulation results.
+
+        Args:
+            results: The simulation results.
+            path: Directory to save the plots to.
+        """
         return epl.plot.plot_battery(results, pathlib.Path(path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ build-backend = "poetry.core.masonry.api"
 exclude_also =[
   "@(abc\\.)?abstractmethod"
 ]
+
+[tool.pylint]
+load-plugins = "pylint.extensions.docparams"

--- a/tests/assets/test_battery.py
+++ b/tests/assets/test_battery.py
@@ -257,6 +257,7 @@ def test_hypothesis(
     mask = simulation.results[f"{name}-electric_discharge_mwh"] > 0
     subset = simulation.results[mask]
     assert all(subset[f"{name}-electric_loss_mwh"] == 0)
+    np.testing.assert_allclose(subset[f"{name}-electric_loss_mwh"], 0)
 
 
 def test_import_export_prices() -> None:

--- a/tests/assets/test_battery.py
+++ b/tests/assets/test_battery.py
@@ -316,3 +316,37 @@ def test_no_simultaneous_import_export() -> None:
     results = simulation.results
 
     check_no_simultaneous(results, "site-import_power_mwh", "site-export_power_mwh")
+
+
+@hypothesis.settings(
+    print_blob=True,
+    max_examples=25,
+    verbosity=hypothesis.Verbosity.verbose,
+    deadline=20000,
+)
+@hypothesis.given(
+    charge_mw=hypothesis.strategies.floats(min_value=1.0, max_value=100),
+    discharge_mw=hypothesis.strategies.floats(min_value=1.0, max_value=100),
+)
+def test_different_charge_discharge_rates(
+    charge_mw: float, discharge_mw: float
+) -> None:
+    """Test that we can charge and discharge our battery at different rates."""
+    prices = np.random.uniform(-1000, 1000, 512)
+    capacity = 100
+    asset = epl.Battery(
+        power_mw=charge_mw,
+        discharge_power_mw=discharge_mw,
+        capacity_mwh=capacity,
+        initial_charge_mwh=0,
+        final_charge_mwh=capacity,
+        efficiency_pct=1.0,
+        electricity_prices=prices,
+    )
+    simulation = asset.optimize()
+    np.testing.assert_allclose(
+        simulation.results["battery-electric_charge_mwh"].max(), charge_mw
+    )
+    np.testing.assert_allclose(
+        simulation.results["battery-electric_discharge_mwh"].max(), discharge_mw
+    )


### PR DESCRIPTION
Allows setting of battery charge and discharge power (both in megawatts) separately.

Also improves the battery documentation, and starts work on docstring linting in `make lint-docstrings`.  This relies on `pydocstyle` and `pylint` - both of these have not been added to the `pyproject.toml` yet.